### PR TITLE
Added support for Ubuntu 16.04 running systemd

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,7 @@ platforms:
     driver_config:
       customize:
         memory: 768
+  - name: ubuntu-16.04
 
 suites:
   - name: default

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source 'http://api.berkshelf.com'
+source 'https://supermarket.chef.io'
 
 metadata

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,5 +7,5 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '1.0.1'
 
 depends 'chef-solo-search', '~> 0.5.1'
-depends 'openssh', '~> 1.3.4'
+depends 'openssh', '~> 1.5.0'
 depends 'users', '~> 1.7.0'


### PR DESCRIPTION
Failure on Ubuntu 16.04 with default systemd.  The `openssh` cookbook fixed this issue in version `1.5.0`.  I updated `metadata.rb` and added a platform in test kitchen, all tests passed.

```          ================================================================================
           Error executing action `enable` on resource 'service[ssh]'
           ================================================================================

           Errno::ENOENT
           -------------
           No such file or directory - /sbin/status

           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/openssh/recipes/default.rb

            32: service 'ssh' do
            33:   provider service_provider
            34:   service_name node['openssh']['service_name']
            35:   supports value_for_platform(
            36:     'debian' => { 'default' => [:restart, :reload, :status] },
            37:     'ubuntu' => {
            38:       '8.04' => [:restart, :reload],
            39:       'default' => [:restart, :reload, :status]
            40:     },
            41:     'centos' => { 'default' => [:restart, :reload, :status] },
            42:     'redhat' => { 'default' => [:restart, :reload, :status] },
            43:     'fedora' => { 'default' => [:restart, :reload, :status] },
            44:     'scientific' => { 'default' => [:restart, :reload, :status] },
            45:     'arch' => { 'default' => [:restart] },
            46:     'default' => { 'default' => [:restart, :reload] }
            47:   )
            48:   action [:enable, :start]
            49: end
            50:

           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cache/cookbooks/openssh/recipes/default.rb:32:in `from_file'

           service("ssh") do
             provider Chef::Provider::Service::Upstart
             action [:enable, :start]
             supports {:restart=>true, :reload=>true, :status=>true}
             retries 0
             retry_delay 2
             default_guard_interpreter :default
             service_name "ssh"
             enabled nil
             running nil
             masked nil
             pattern "ssh"
             declared_type :service
             cookbook_name "openssh"
             recipe_name "default"
           end

           Platform:
           ---------
           x86_64-linux```